### PR TITLE
fix: use dollar-quoted strings

### DIFF
--- a/src/main/resources/snowflake/rest.feature
+++ b/src/main/resources/snowflake/rest.feature
@@ -94,7 +94,7 @@ Feature: rest
   args = { "recordMetadata": {...}, "recordValue": {...} }
     * string rm = recordMetadata
     * string rv = recordValue
-    * string result = "('"+rm+"','"+rv+"')"
+    * string result = "($$"+rm+"$$,$$"+rv+"$$)"
 
   @insertRowIntoStagingTable
   Scenario: insertRowIntoStagingTable


### PR DESCRIPTION
As said in Snowflake documentation https://docs.snowflake.com/en/sql-reference/data-types-text#label-dollar-quoted-string-constants

In some cases, you might need to specify a string constant that contains:
    Single quote characters.
    Backslash characters (for example, in a regular expression).
    Newline characters (for example, in the body of a stored procedure or function that you specify in CREATE PROCEDURE or CREATE FUNCTION).

Example that could not work without dollar quoted strings :

```sql
select parse_json('{"foo":"Bar\nBaz\nQux\n"}');
```

Example that works :

```sql
select parse_json($${"foo":"Bar\nBaz\nQux\n"}$$);
```

FIX: https://github.com/lectra-tech/karate-connect/issues/68