### PR TITLE
Feat/nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ target
 # Python
 py_venv
 
+# devenv / direnv
+.devenv*
+devenv.local.nix
+.direnv
+
 # Snowflake
 snowflake.properties
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ build.gradle.kts                       # build, fat JAR, extension JS code gener
 gradle/libs.versions.toml              # version catalog (all dependency versions live here)
 compose.yml + Dockerfile_*             # builder -> minimal -> python -> nominal / aks images
 devenv.nix / devenv.yaml               # optional Nix dev environment (devenv.sh)
+flake.nix + nix/*.nix                  # optional Nix module for consumers to run Karate tests
 entrypoint.sh                          # Docker entrypoint (KARATE_EXTENSIONS -> -Dextensions)
 docs/headers/                          # license header templates + add-headers.sh
 src/main/kotlin/com/lectra/karate/connect/
@@ -66,6 +67,36 @@ devenv test    # fat JAR + tests on $TEST_EXTENSIONS
 It uses a project-local `GRADLE_USER_HOME` (under `.devenv/state/`) and clears the extension
 environment variables (`KAFKA_*`, `RABBITMQ_*`, `SNOWFLAKE_*`), which the `configFromEnv` test
 scenarios require to be unset. Docker is not provided: `kc-docker-build` uses the host daemon.
+
+### Optional: `flake.nix` — reusable Nix module for consumers
+
+`flake.nix` + `nix/*.nix` let **other** Nix projects import karate-connect and run its Karate CLI
+against their own features, with every setting customizable (extensions, features path,
+`karate-config.js` location, tags, threads, output format, environment variables, JVM args). This is
+for consumers of karate-connect, not for building karate-connect itself (which is still done with
+Gradle as above).
+
+- The JAR is **fetched from a pinned GitHub Release** (`nix/default-jar.nix`, `fetchurl` +
+  content hash) — it is not rebuilt from source by Nix.
+- `nix/karate-run-options.nix` is the single shared option set (submodule); `nix/build-karate-run.nix`
+  turns one evaluated config into a `writeShellApplication` wrapper that invokes
+  `com.intuit.karate.Main` with `-cp "<jar>:<featuresPath>:<karateConfigDir>:<extraClasspath>"`
+  (not `-jar`, so that `classpath:...` reads inside features can find files on disk next to the
+  consumer's own feature/config directories).
+- Three adapters wrap that same core, so behavior never diverges:
+  - `flakeModules.default` — flake-parts module: `perSystem.karate-connect.runs.<name>` →
+    `packages`/`apps` named `karate-test-<name>`.
+  - `lib.mkKarateRun` — plain function (`lib.evalModules` under the hood) for consumers without
+    flake-parts.
+  - `devenvModules.default` — devenv module: `karate-connect.runs.<name>` → a `karate-<name>` script.
+- This repo dogfoods the module itself: `checks.kubernetes-smoke` (`nix flake check`) runs the
+  `kubernetes` extension against the existing **mocked** `cronJob.test.feature` — fully offline,
+  no `kubectl`/network needed — proving the fetch → wrapper → Karate run chain end-to-end.
+
+```bash
+nix run .#karate-test-kubernetes-smoke   # this repo's own dogfood run
+nix flake check                          # includes the same run as checks.kubernetes-smoke
+```
 
 ## How extensions work (important)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+Instructions for coding agents working on `karate-connect`.
+
+## Overview
+
+`karate-connect` packages [Karate Core](https://github.com/karatelabs/karate) plus **extensions**
+(`base`, `rabbitmq`, `kafka`, `snowflake`, `dbt`, `kubernetes`) into a fat JAR
+(`karate-connect-<version>-standalone.jar`, main class `com.intuit.karate.Main`) and a set of Docker images.
+
+An extension is a folder under `src/main/resources/<extension>/` combining Karate feature files,
+a `karate-ext-config.js`, and optionally Kotlin helper classes.
+
+Stack: Kotlin/JVM (toolchain 21), Gradle Kotlin DSL, JUnit 5, Docker Compose, Python (Snowflake CLI & dbt).
+
+## Project layout
+
+```
+build.gradle.kts                       # build, fat JAR, extension JS code generation
+gradle/libs.versions.toml              # version catalog (all dependency versions live here)
+compose.yml + Dockerfile_*             # builder -> minimal -> python -> nominal / aks images
+entrypoint.sh                          # Docker entrypoint (KARATE_EXTENSIONS -> -Dextensions)
+docs/headers/                          # license header templates + add-headers.sh
+src/main/kotlin/com/lectra/karate/connect/
+    Extension.kt                       # enum of supported extensions
+    BrokerClient.kt, rabbitmq/, kafka/ # Kotlin clients called from features
+src/main/resources/
+    karate-base.js                     # `base` extension, always loaded
+    <extension>/karate-ext-config.js   # extension config, exposed as `<extension>.<key>`
+    <extension>/*.feature              # extension API (see below)
+src/test/resources/
+    karate-config.js                   # test-side config (e.g. Snowflake PEM init)
+    <extension>/*.test.feature         # integration tests
+src/test/kotlin/com/lectra/karate/connect/
+    AllFeaturesTest.kt                 # JUnit 5 runner, parallel(16)
+    LocalBroker.kt, kafka/, rabbitmq/  # embedded brokers for tests
+```
+
+## Build & test commands
+
+```bash
+source .envrc                      # creates py_venv, installs requirements.txt (or: direnv allow)
+./gradlew build                    # fat JAR + all tests
+./gradlew build -DtestExtensions=rabbitmq,kafka,kubernetes   # default subset, skips Snowflake/dbt
+./gradlew test --tests '*AllFeaturesTest*'                   # tests only
+./gradlew karateVersion            # prints the Karate version in use
+docker compose build               # builds all 5 local images
+```
+
+- `-DtestExtensions` (default `rabbitmq,kafka,kubernetes`) selects which extensions are exercised.
+  Use it whenever no Snowflake account is configured — Snowflake/dbt tests will otherwise fail.
+- Tests are always re-run (`outputs.upToDateWhen { false }`).
+- The project version comes from `git describe --tags` (grgit), so a shallow clone without tags yields `0.0.0`.
+
+## How extensions work (important)
+
+`processResources` in `build.gradle.kts` walks every directory under `src/main/resources/` and
+**generates `<extension>/<extension>.js`** from the feature files it finds. Each scenario becomes a
+callable function:
+
+```gherkin
+* def result = <extension>.<featureFile>.<scenarioName>(args)
+```
+
+Consequences:
+
+- **A scenario name is public API.** Renaming a scenario is a breaking change.
+- Scenarios tagged `@ignore` and features tagged `@deprecated` are excluded from generation;
+  `Scenario Outline` sections are ignored too.
+- The generated `<extension>.js` is a build artifact under `build/resources/main/`. Never commit or
+  hand-edit it; regenerate with `./gradlew processResources`.
+- Adding an extension = create `src/main/resources/<name>/` **and** add `<name>` to the
+  `Extension` enum in `Extension.kt`, plus tests in `src/test/resources/<name>/`.
+
+At runtime, `karate-base.js` reads `karate.properties["extensions"]` and loads
+`classpath:<ext>/karate-ext-config.js` for each one; its returned object is exposed as `<ext>.<key>`.
+A missing extension is only logged, never fatal.
+
+## Conventions
+
+- **License headers are mandatory.** Every `.kt` and `.js` file starts with the star header, every
+  `.feature` with the sharp header (`docs/headers/*-header-comment.txt`). Run
+  `docs/headers/add-headers.sh` after adding files; it rewrites headers in place. Markdown/AsciiDoc
+  files are not headered.
+- **Feature files** follow a fixed shape: `@ignore` on the `Feature:` line, one tag per scenario
+  matching the scenario name, an `args: { ... }` comment documenting the payload, and a result of
+  the form `json result = { status: "OK", data }` (`"FAILED"` on error).
+- Optional arguments are read with `karate.get("name", default)`.
+- **Dependencies** are declared only in `gradle/libs.versions.toml` (Renovate keeps them updated);
+  never hardcode versions in `build.gradle.kts`.
+- **Commits**: conventional commit messages (`fix:`, `feat:`, `chore:`, `doc:`) and a DCO sign-off is
+  required — `git commit -s`. See `CONTRIBUTING.adoc`.
+
+## Gotchas
+
+- Snowflake and dbt tests need `src/test/resources/snowflake/snowflake.properties` (gitignored,
+  see `snowflake.template.properties`). **Never commit credentials** or create that file with real values.
+- Kafka and RabbitMQ tests run against embedded brokers started by `AllFeaturesTest`; no external
+  service is required for them.
+- The `base` extension is always loaded; the others are enabled via `-Dextensions=...`
+  (or `KARATE_EXTENSIONS` in Docker).
+- `build/`, `py_venv/`, `target/`, `*.jar` and `snowflake.properties` are gitignored — don't add them.
+- Any change to a public extension API (scenario names, config keys, arguments) must be reflected in
+  the corresponding section of `README.adoc`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Stack: Kotlin/JVM (toolchain 21), Gradle Kotlin DSL, JUnit 5, Docker Compose, Py
 build.gradle.kts                       # build, fat JAR, extension JS code generation
 gradle/libs.versions.toml              # version catalog (all dependency versions live here)
 compose.yml + Dockerfile_*             # builder -> minimal -> python -> nominal / aks images
+devenv.nix / devenv.yaml               # optional Nix dev environment (devenv.sh)
 entrypoint.sh                          # Docker entrypoint (KARATE_EXTENSIONS -> -Dextensions)
 docs/headers/                          # license header templates + add-headers.sh
 src/main/kotlin/com/lectra/karate/connect/
@@ -51,6 +52,20 @@ docker compose build               # builds all 5 local images
   Use it whenever no Snowflake account is configured — Snowflake/dbt tests will otherwise fail.
 - Tests are always re-run (`outputs.upToDateWhen { false }`).
 - The project version comes from `git describe --tags` (grgit), so a shallow clone without tags yields `0.0.0`.
+
+### Optional: devenv
+
+[devenv](https://devenv.sh) provides the whole toolchain (JDK 21, Python CLIs, `kubectl`) without
+installing anything system-wide. It is opt-in and does not interfere with `.envrc`/`py_venv`.
+
+```bash
+devenv shell   # toolchain + kc-build / kc-build-all / kc-test / kc-docker-build / kc-headers
+devenv test    # fat JAR + tests on $TEST_EXTENSIONS
+```
+
+It uses a project-local `GRADLE_USER_HOME` (under `.devenv/state/`) and clears the extension
+environment variables (`KAFKA_*`, `RABBITMQ_*`, `SNOWFLAKE_*`), which the `configFromEnv` test
+scenarios require to be unset. Docker is not provided: `kc-docker-build` uses the host daemon.
 
 ## How extensions work (important)
 

--- a/README.adoc
+++ b/README.adoc
@@ -338,6 +338,10 @@ nix run .#karate-test-default             # runs the "default" run
 nix run .#karate-test-kubernetes-smoke     # runs the "kubernetes-smoke" run
 nix run .#karate-test-docker-style         # runs the "docker-style" run, /features bind-mounted
 nix flake check                            # if wired into `checks.*`, see this repo's own flake.nix
+
+# Any argument passed after `--` replaces `featuresPath` for that invocation only,
+# exactly like `docker run <image> <karate_args>` overrides the image's default `CMD`:
+nix run .#karate-test-default -- src/test/features/foo.feature
 ----
 
 === Usage without flake-parts (`lib.mkKarateRun`)
@@ -432,6 +436,10 @@ inputs:
 devenv shell                        # enter the shell, exposes karate-default & karate-docker-style
 devenv shell -- karate-default      # run the "default" run non-interactively
 devenv shell -- karate-docker-style # run the "docker-style" run, /features bind-mounted
+
+# Any argument passed to the script replaces `featuresPath` for that invocation only,
+# exactly like `docker run <image> <karate_args>` overrides the image's default `CMD`:
+devenv shell -- karate-default src/test/features/foo.feature
 ----
 
 === Dogfooding

--- a/README.adoc
+++ b/README.adoc
@@ -179,17 +179,17 @@ store).
 
 | `featuresMountPath`
 | `null`
-| Absolute path at which `featuresPath` should appear to the running JVM, bind-mounted at run time
-via `bubblewrap` (`bwrap`) -- the same remapping Docker usage does with `-v <features_path>:/features`
-(see the Docker image's `VOLUME /features`). Useful when feature files were written assuming that
-Docker layout (e.g. reading fixtures from a hardcoded absolute path). Example: with
-`featuresPath = "it/features"` and `featuresMountPath = "/features"`, the host directory
-`it/features` (resolved against the invoking shell's working directory) is bind-mounted onto
-`/features` for the JVM process only -- no Nix store copy, no change to the real filesystem
-outside the wrapped process. Leave `null` (the default) to run directly against `featuresPath`,
-with no remapping. Only supported on Linux (`bubblewrap` is not available on Darwin); evaluation
-fails with a clear error if set on a non-Linux system. Must be a real subpath (e.g. `/features`),
-not `/` itself.
+| Absolute path at which `featuresPath` should appear to the running JVM, bind-mounted at run
+time -- the same remapping Docker usage does with `-v <features_path>:/features` (see the Docker
+image's `VOLUME /features`). Implemented with `bubblewrap` (`bwrap`) on Linux, or `bindfs` on
+Darwin (see the note below the table); evaluation fails with a clear error on any other platform.
+Useful when feature files were written assuming that Docker layout (e.g. reading fixtures from a
+hardcoded absolute path). Example: with `featuresPath = "it/features"` and
+`featuresMountPath = "/features"`, the host directory `it/features` (resolved against the
+invoking shell's working directory) is bind-mounted onto `/features` for the JVM process only --
+no Nix store copy, no change to the real filesystem outside the wrapped process. Leave `null`
+(the default) to run directly against `featuresPath`, with no remapping. Must be a real subpath
+(e.g. `/features`), not `/` itself.
 
 | `karateConfigDir`
 | `null`
@@ -200,18 +200,18 @@ default resolution (classpath / current directory).
 | `karateConfigMountPath`
 | `null`
 | Absolute path at which `karateConfigDir` should appear to the running JVM, bind-mounted at run
-time via `bubblewrap` (`bwrap`) -- the same remapping Docker usage does with
-`-v <my-specific-karate-config.js>:/karate-config.js`. `karate-config.js` (or code it calls into)
-sometimes reads auxiliary files via a hardcoded absolute path too, the same problem
-`featuresMountPath` solves for `featuresPath`. Example: with `karateConfigDir = "it/config"` and
-`karateConfigMountPath = "/karate-config"`, the host directory `it/config` is bind-mounted onto
-`/karate-config` for the JVM process only, and `-Dkarate.config.dir` is set to the mounted path.
-Requires `karateConfigDir` to also be set. Leave `null` (the default) to run directly against
-`karateConfigDir`, with no remapping. Only supported on Linux; evaluation fails with a clear error
-if set on a non-Linux system. Must be a real subpath (e.g. `/karate-config`), not `/` itself --
-`featuresMountPath` and `karateConfigMountPath` share the same sandbox, built as one fresh writable
-root with `/nix`, `/dev`, `/proc`, `/etc`, `/run`, `/tmp` and the caller's working directory
-re-bound onto it, so mounting directly onto `/` would hide those.
+time -- the same remapping Docker usage does with `-v <my-specific-karate-config.js>:/karate-config.js`.
+Implemented the same way as `featuresMountPath` (`bubblewrap` on Linux, `bindfs` on Darwin).
+`karate-config.js` (or code it calls into) sometimes reads auxiliary files via a hardcoded
+absolute path too, the same problem `featuresMountPath` solves for `featuresPath`. Example: with
+`karateConfigDir = "it/config"` and `karateConfigMountPath = "/karate-config"`, the host directory
+`it/config` is bind-mounted onto `/karate-config` for the JVM process only, and
+`-Dkarate.config.dir` is set to the mounted path. Requires `karateConfigDir` to also be set. Leave
+`null` (the default) to run directly against `karateConfigDir`, with no remapping. Must be a real
+subpath (e.g. `/karate-config`), not `/` itself -- `featuresMountPath` and `karateConfigMountPath`
+share the same sandbox on Linux, built as one fresh writable root with `/nix`, `/dev`, `/proc`,
+`/etc`, `/run`, `/tmp` and the caller's working directory re-bound onto it, so mounting directly
+onto `/` would hide those.
 
 | `outputDir`
 | `"target/karate-reports"`
@@ -258,6 +258,18 @@ runtime against the invoking shell's working directory. Needed when a feature re
 resource via `classpath:...` (e.g. a mock JSON fixture) from outside `featuresPath`. Example:
 `[ "src/test/fixtures" ]`.
 |===
+
+NOTE: `featuresMountPath` and `karateConfigMountPath` require either Linux (`bubblewrap`,
+zero-config) or macOS (`bindfs`). macOS has no equivalent of Linux user/mount namespaces, so on
+Darwin these options fall back to `bindfs`, a FUSE filesystem, with two consequences the Linux
+path doesn't have: (1) it requires https://github.com/macfuse/macfuse[macFUSE^] to be installed
+and approved by the user once -- a system extension outside of Nix's control; (2) unlike the
+disposable Linux sandbox, `bindfs` mounts onto the *real* filesystem, so the mount target (e.g.
+`/features`) must already exist as a directory the invoking user owns (create it once with
+`sudo mkdir -p /features && sudo chown "$(whoami)" /features`) -- the run fails with a clear
+message otherwise. The Darwin path is less exercised than the Linux one; treat it as best-effort.
+If neither is workable, running the Docker image directly (Docker Desktop already provides the
+equivalent Linux environment on macOS) remains the simplest option.
 
 === Usage with flake-parts (`flakeModules.default`)
 

--- a/README.adoc
+++ b/README.adoc
@@ -188,13 +188,30 @@ Docker layout (e.g. reading fixtures from a hardcoded absolute path). Example: w
 `/features` for the JVM process only -- no Nix store copy, no change to the real filesystem
 outside the wrapped process. Leave `null` (the default) to run directly against `featuresPath`,
 with no remapping. Only supported on Linux (`bubblewrap` is not available on Darwin); evaluation
-fails with a clear error if set on a non-Linux system.
+fails with a clear error if set on a non-Linux system. Must be a real subpath (e.g. `/features`),
+not `/` itself.
 
 | `karateConfigDir`
 | `null`
 | Directory containing a custom `karate-config.js`, passed as `-Dkarate.config.dir=<dir>`.
 Resolved at runtime against the invoking shell's working directory. Leave `null` to use Karate's
 default resolution (classpath / current directory).
+
+| `karateConfigMountPath`
+| `null`
+| Absolute path at which `karateConfigDir` should appear to the running JVM, bind-mounted at run
+time via `bubblewrap` (`bwrap`) -- the same remapping Docker usage does with
+`-v <my-specific-karate-config.js>:/karate-config.js`. `karate-config.js` (or code it calls into)
+sometimes reads auxiliary files via a hardcoded absolute path too, the same problem
+`featuresMountPath` solves for `featuresPath`. Example: with `karateConfigDir = "it/config"` and
+`karateConfigMountPath = "/karate-config"`, the host directory `it/config` is bind-mounted onto
+`/karate-config` for the JVM process only, and `-Dkarate.config.dir` is set to the mounted path.
+Requires `karateConfigDir` to also be set. Leave `null` (the default) to run directly against
+`karateConfigDir`, with no remapping. Only supported on Linux; evaluation fails with a clear error
+if set on a non-Linux system. Must be a real subpath (e.g. `/karate-config`), not `/` itself --
+`featuresMountPath` and `karateConfigMountPath` share the same sandbox, built as one fresh writable
+root with `/nix`, `/dev`, `/proc`, `/etc`, `/run`, `/tmp` and the caller's working directory
+re-bound onto it, so mounting directly onto `/` would hide those.
 
 | `outputDir`
 | `"target/karate-reports"`
@@ -286,14 +303,17 @@ Exposes `perSystem.karate-connect.runs.<name>`, producing a `packages`/`apps` pa
           tags = "@kubernetes";
         };
 
-        # A third run: features written for the Docker layout, reading
-        # fixtures from a hardcoded `/features/...` path. `it/features` (on
-        # disk, next to this flake.nix) is bind-mounted onto `/features` for
-        # the JVM only, mirroring `docker run -v it/features:/features ...`.
+        # A third run: features and config written for the Docker layout,
+        # reading fixtures/config from hardcoded absolute paths. `it/features`
+        # and `it/config` (on disk, next to this flake.nix) are bind-mounted
+        # onto `/features` and `/karate-config` for the JVM only, mirroring
+        # `docker run -v it/features:/features -v it/config/karate-config.js:/karate-config.js ...`.
         karate-connect.runs.docker-style = {
           extensions = [ "rabbitmq" ];
           featuresPath = "it/features";
           featuresMountPath = "/features";
+          karateConfigDir = "it/config";
+          karateConfigMountPath = "/karate-config";
         };
       };
     };
@@ -380,14 +400,17 @@ inputs:
     };
   };
 
-  # Features written for the Docker layout, reading fixtures from a
-  # hardcoded `/features/...` path. `it/features` (on disk, next to this
-  # devenv.nix) is bind-mounted onto `/features` for the JVM only, mirroring
-  # `docker run -v it/features:/features ...`.
+  # Features and config written for the Docker layout, reading fixtures/config
+  # from hardcoded absolute paths. `it/features` and `it/config` (on disk,
+  # next to this devenv.nix) are bind-mounted onto `/features` and
+  # `/karate-config` for the JVM only, mirroring
+  # `docker run -v it/features:/features -v it/config/karate-config.js:/karate-config.js ...`.
   karate-connect.runs.docker-style = {
     extensions = [ "rabbitmq" ];
     featuresPath = "it/features";
     featuresMountPath = "/features";
+    karateConfigDir = "it/config";
+    karateConfigMountPath = "/karate-config";
   };
 }
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,30 @@ Commands::
 ** `karate-connect`
 ** `karate-connect:aks`
 
+=== Optional: devenv
+
+https://devenv.sh[devenv^] provides the whole build/test toolchain (JDK 21, Python CLIs, `kubectl`)
+without installing anything system-wide. It is opt-in and does not interfere with `.envrc`/`py_venv`.
+
+[source,bash]
+----
+devenv shell   # enter the dev environment
+devenv test    # fat JAR + tests on $TEST_EXTENSIONS, same check as CI
+----
+
+Once inside the shell, the following scripts are available :
+
+* `kc-build` : fat JAR + tests on `$TEST_EXTENSIONS` (defaults to `rabbitmq,kafka,kubernetes`)
+* `kc-build-all` : fat JAR + tests on every extension (Snowflake credentials required)
+* `kc-test` : tests only
+* `kc-docker-build` : build the Docker images (uses the host Docker daemon)
+* `kc-headers` : re-apply the license headers
+
+NOTE: Entering the shell clears any `KAFKA_*`/`RABBITMQ_*`/`SNOWFLAKE_*` environment variables
+inherited from your own shell, since the `configFromEnv` test scenarios require them to be unset.
+Snowflake and dbt tests are skipped unless `src/test/resources/snowflake/snowflake.properties`
+exists (see the Snowflake requirements above).
+
 == How to run `karate-connect` on your features
 
 === Docker usage
@@ -103,6 +127,252 @@ function fn() {
 [source,bash]
 ----
 java -Dextensions=<ext1>,<ext2>... -jar karate-connect-<version>-standalone.jar <karate_args>
+----
+
+== Using karate-connect from Nix (`flake.nix`)
+
+`flake.nix` (and the `nix/*.nix` files it imports) is a reusable Nix module for *other* Nix
+projects that want to run `karate-connect`'s Karate CLI against their own features, with every
+setting customizable (extensions, features path, `karate-config.js` location, tags, threads,
+report format, environment variables, JVM args, ...). This is for *consumers* of
+`karate-connect`, not for building `karate-connect` itself (that is still done with Gradle, see
+above).
+
+NOTE: The JAR used at runtime is fetched from a pinned GitHub Release, not rebuilt from source.
+
+Three adapters share the same option set (defined below), so their behavior never diverges :
+a https://flake.parts[flake-parts^] module (`flakeModules.default`), a plain function for
+consumers without flake-parts (`lib.mkKarateRun`), and a https://devenv.sh[devenv^] module
+(`devenvModules.default`).
+
+=== Options
+
+Every "run" (a `karate-connect.runs.<name>` entry, or the attribute set passed to
+`lib.mkKarateRun`) supports the following options :
+
+[cols="2,2,5", options="header"]
+|===
+| Option | Default | Description
+
+| `jar`
+| pinned release JAR
+| The karate-connect standalone JAR to run. Defaults to a pinned release fetched from GitHub
+Releases. Override with a custom build (e.g. a fork, or a locally built `-standalone.jar`) if
+needed.
+
+| `jdk`
+| `pkgs.temurin-bin-21`
+| JDK used to run the JAR. Defaults to JDK 21, matching karate-connect's own Gradle toolchain and
+Docker builder image.
+
+| `extensions`
+| `[ "base" ]`
+| List of extensions to load, passed as `-Dextensions=<ext1>,<ext2>,...`. One of `base`,
+`rabbitmq`, `kafka`, `snowflake`, `dbt`, `kubernetes`. `base` is always loaded by karate-connect
+itself regardless of this list.
+
+| `featuresPath`
+| `"features"`
+| Path to the feature file(s) or directory to run, resolved at runtime against the invoking
+shell's working directory (kept as a plain string, not a Nix path, so it is never copied into the
+store).
+
+| `karateConfigDir`
+| `null`
+| Directory containing a custom `karate-config.js`, passed as `-Dkarate.config.dir=<dir>`.
+Resolved at runtime against the invoking shell's working directory. Leave `null` to use Karate's
+default resolution (classpath / current directory).
+
+| `outputDir`
+| `"target/karate-reports"`
+| Report output directory, passed as `-o`.
+
+| `tags`
+| `null`
+| Tag expression filter, passed as `-t`. Example: `"@smoke"`.
+
+| `threads`
+| `1`
+| Parallel thread count, passed as `-T`.
+
+| `format`
+| `[ "junit:xml" "cucumber:json" ]`
+| Report formats, comma-joined and passed as `-f`.
+
+| `env`
+| `null`
+| Karate environment name, passed as `-e` (`karate.env`). Example: `"dev"`.
+
+| `name`
+| `null`
+| Scenario name filter, passed as `-n`.
+
+| `environmentVariables`
+| `{ }`
+| OS environment variables exported before running, e.g. the `RABBITMQ_*`/`KAFKA_*`/`SNOWFLAKE_*`
+variables read by karate-connect's extensions, or any variable a consumer's own
+`karate-config.js` relies on. Example: `{ RABBITMQ_HOST = "localhost"; KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"; }`.
+
+| `jvmArgs`
+| `[ ]`
+| Extra JVM arguments (e.g. heap size, custom system properties). Example: `[ "-Xmx2g" ]`.
+
+| `extraArgs`
+| `[ ]`
+| Escape hatch: extra arguments appended verbatim to the Karate CLI invocation.
+
+| `extraClasspath`
+| `[ ]`
+| Extra directories added to the JVM classpath alongside the JAR and `featuresPath`, resolved at
+runtime against the invoking shell's working directory. Needed when a feature reads a sibling
+resource via `classpath:...` (e.g. a mock JSON fixture) from outside `featuresPath`. Example:
+`[ "src/test/fixtures" ]`.
+|===
+
+=== Usage with flake-parts (`flakeModules.default`)
+
+Exposes `perSystem.karate-connect.runs.<name>`, producing a `packages`/`apps` pair named
+`karate-test-<name>`.
+
+.Full example `flake.nix`
+[source,nix]
+----
+{
+  description = "My project's Karate integration tests";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    karate-connect.url = "github:lectra-tech/karate-connect";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      imports = [ inputs.karate-connect.flakeModules.default ];
+
+      perSystem = { pkgs, ... }: {
+        karate-connect.runs.default = {
+          extensions = [ "rabbitmq" "kafka" ];
+          featuresPath = "src/test/features";
+          karateConfigDir = "src/test";
+          tags = "@smoke";
+          threads = 4;
+          environmentVariables = {
+            RABBITMQ_HOST = "localhost";
+            KAFKA_BOOTSTRAP_SERVERS = "localhost:9092";
+          };
+        };
+
+        # A second, independent run: e.g. a Kubernetes-only smoke test.
+        karate-connect.runs.kubernetes-smoke = {
+          extensions = [ "kubernetes" ];
+          featuresPath = "src/test/features/kubernetes";
+          tags = "@kubernetes";
+        };
+      };
+    };
+}
+----
+
+[source,bash]
+----
+nix run .#karate-test-default             # runs the "default" run
+nix run .#karate-test-kubernetes-smoke     # runs the "kubernetes-smoke" run
+nix flake check                            # if wired into `checks.*`, see this repo's own flake.nix
+----
+
+=== Usage without flake-parts (`lib.mkKarateRun`)
+
+A plain function for consumers who do not use flake-parts. It takes the same options plus
+`pkgs`/`lib`/`name`, and returns `{ package, app }`.
+
+[source,nix]
+----
+{
+  description = "My project's Karate integration tests";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    karate-connect.url = "github:lectra-tech/karate-connect";
+  };
+
+  outputs = { self, nixpkgs, karate-connect, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      run = karate-connect.lib.mkKarateRun {
+        inherit pkgs;
+        name = "default";
+        extensions = [ "rabbitmq" "kafka" ];
+        featuresPath = "src/test/features";
+        tags = "@smoke";
+      };
+    in
+    {
+      packages.${system}.karate-test = run.package;
+      apps.${system}.karate-test = run.app;
+    };
+}
+----
+
+[source,bash]
+----
+nix run .#karate-test
+----
+
+=== Usage with devenv (`devenvModules.default`)
+
+Exposes `karate-connect.runs.<name>`, adding a `karate-<name>` script to the devenv shell.
+
+.Full example `devenv.yaml`
+[source,yaml]
+----
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  karate-connect:
+    url: github:lectra-tech/karate-connect
+----
+
+.Full example `devenv.nix`
+[source,nix]
+----
+{ inputs, ... }:
+{
+  imports = [ inputs.karate-connect.devenvModules.default ];
+
+  karate-connect.runs.default = {
+    extensions = [ "rabbitmq" "kafka" ];
+    featuresPath = "src/test/features";
+    karateConfigDir = "src/test";
+    tags = "@smoke";
+    threads = 4;
+    environmentVariables = {
+      RABBITMQ_HOST = "localhost";
+      KAFKA_BOOTSTRAP_SERVERS = "localhost:9092";
+    };
+  };
+}
+----
+
+[source,bash]
+----
+devenv shell                    # enter the shell, exposes the `karate-default` script
+devenv shell -- karate-default  # run it non-interactively
+----
+
+=== Dogfooding
+
+This repo dogfoods the module against its own, fully-mocked `kubernetes` feature (no `kubectl`/network
+access needed) as `checks.kubernetes-smoke` :
+
+[source,bash]
+----
+nix run .#karate-test-kubernetes-smoke   # this repo's own dogfood run
+nix flake check                          # includes the same run as checks.kubernetes-smoke
 ----
 
 == Extensions

--- a/README.adoc
+++ b/README.adoc
@@ -177,6 +177,19 @@ itself regardless of this list.
 shell's working directory (kept as a plain string, not a Nix path, so it is never copied into the
 store).
 
+| `featuresMountPath`
+| `null`
+| Absolute path at which `featuresPath` should appear to the running JVM, bind-mounted at run time
+via `bubblewrap` (`bwrap`) -- the same remapping Docker usage does with `-v <features_path>:/features`
+(see the Docker image's `VOLUME /features`). Useful when feature files were written assuming that
+Docker layout (e.g. reading fixtures from a hardcoded absolute path). Example: with
+`featuresPath = "it/features"` and `featuresMountPath = "/features"`, the host directory
+`it/features` (resolved against the invoking shell's working directory) is bind-mounted onto
+`/features` for the JVM process only -- no Nix store copy, no change to the real filesystem
+outside the wrapped process. Leave `null` (the default) to run directly against `featuresPath`,
+with no remapping. Only supported on Linux (`bubblewrap` is not available on Darwin); evaluation
+fails with a clear error if set on a non-Linux system.
+
 | `karateConfigDir`
 | `null`
 | Directory containing a custom `karate-config.js`, passed as `-Dkarate.config.dir=<dir>`.
@@ -272,6 +285,16 @@ Exposes `perSystem.karate-connect.runs.<name>`, producing a `packages`/`apps` pa
           featuresPath = "src/test/features/kubernetes";
           tags = "@kubernetes";
         };
+
+        # A third run: features written for the Docker layout, reading
+        # fixtures from a hardcoded `/features/...` path. `it/features` (on
+        # disk, next to this flake.nix) is bind-mounted onto `/features` for
+        # the JVM only, mirroring `docker run -v it/features:/features ...`.
+        karate-connect.runs.docker-style = {
+          extensions = [ "rabbitmq" ];
+          featuresPath = "it/features";
+          featuresMountPath = "/features";
+        };
       };
     };
 }
@@ -281,6 +304,7 @@ Exposes `perSystem.karate-connect.runs.<name>`, producing a `packages`/`apps` pa
 ----
 nix run .#karate-test-default             # runs the "default" run
 nix run .#karate-test-kubernetes-smoke     # runs the "kubernetes-smoke" run
+nix run .#karate-test-docker-style         # runs the "docker-style" run, /features bind-mounted
 nix flake check                            # if wired into `checks.*`, see this repo's own flake.nix
 ----
 
@@ -355,13 +379,24 @@ inputs:
       KAFKA_BOOTSTRAP_SERVERS = "localhost:9092";
     };
   };
+
+  # Features written for the Docker layout, reading fixtures from a
+  # hardcoded `/features/...` path. `it/features` (on disk, next to this
+  # devenv.nix) is bind-mounted onto `/features` for the JVM only, mirroring
+  # `docker run -v it/features:/features ...`.
+  karate-connect.runs.docker-style = {
+    extensions = [ "rabbitmq" ];
+    featuresPath = "it/features";
+    featuresMountPath = "/features";
+  };
 }
 ----
 
 [source,bash]
 ----
-devenv shell                    # enter the shell, exposes the `karate-default` script
-devenv shell -- karate-default  # run it non-interactively
+devenv shell                        # enter the shell, exposes karate-default & karate-docker-style
+devenv shell -- karate-default      # run the "default" run non-interactively
+devenv shell -- karate-docker-style # run the "docker-style" run, /features bind-mounted
 ----
 
 === Dogfooding

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1785352168,
+        "narHash": "sha256-m/9I5Ai3+wbJuKXtwwaFLG+4Db7Pg2EUYP3ZGLsA7xU=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "bf3fde552a27d5e41c52c0fcfbf258e396c995bb",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1785104946,
+        "narHash": "sha256-VLSslwCjlsICjyaUfrS7lGMypmO03fzmDAqhD85Ae84=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "c946ff36bf193309589932c371bd5ae6653c912e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784783405,
+        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,187 @@
+{ pkgs, lib, config, ... }:
+
+let
+  # Every environment variable read by an extension's `configFromEnv`. The
+  # `*.test.feature` config scenarios assert that these resolve to null, so any
+  # value inherited from the developer's shell makes the test suite fail. They
+  # are cleared when entering the shell to keep local runs reproducible.
+  extensionEnvVars = [
+    "KAFKA_BOOTSTRAP_SERVERS"
+    "KAFKA_KARATE_CONNECT_CONSUMER_GROUP_ID_PREFIX"
+    "KAFKA_PASSWORD"
+    "KAFKA_SASL_MECHANISM"
+    "KAFKA_SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE"
+    "KAFKA_SCHEMA_REGISTRY_KEY"
+    "KAFKA_SCHEMA_REGISTRY_SECRET"
+    "KAFKA_SCHEMA_REGISTRY_URL"
+    "KAFKA_SECURITY_PROTOCOL"
+    "KAFKA_USERNAME"
+    "PRIVATE_KEY_PASSPHRASE"
+    "RABBITMQ_HOST"
+    "RABBITMQ_PASSWORD"
+    "RABBITMQ_PORT"
+    "RABBITMQ_SSL"
+    "RABBITMQ_USERNAME"
+    "RABBITMQ_VIRTUAL_HOST"
+    "SNOWFLAKE_ACCOUNT"
+    "SNOWFLAKE_DATABASE"
+    "SNOWFLAKE_PRIVATE_KEY_PATH"
+    "SNOWFLAKE_ROLE"
+    "SNOWFLAKE_SCHEMA"
+    "SNOWFLAKE_USER"
+    "SNOWFLAKE_WAREHOUSE"
+  ];
+
+  clearExtensionEnv = ''
+    cleared=""
+    for var in ${lib.concatStringsSep " " extensionEnvVars}; do
+      if [ -n "''${!var:-}" ]; then
+        cleared="$cleared $var"
+        unset "$var"
+      fi
+    done
+  '';
+in
+{
+  # ---------------------------------------------------------------------------
+  # Toolchain
+  # ---------------------------------------------------------------------------
+
+  # JDK 21, same major version as the Docker builder image (eclipse-temurin:21)
+  # and as the Gradle toolchain declared in build.gradle.kts.
+  # This also exports JAVA_HOME, which Gradle toolchain resolution relies on.
+  languages.java.enable = true;
+  languages.java.jdk.package = pkgs.temurin-bin-21;
+
+  # Python 3.12 backs the `snowflake` and `dbt` extensions, which shell out to
+  # the `snow` and `dbt` CLIs. It is pinned because those CLIs do not support
+  # the current nixpkgs default interpreter yet.
+  languages.python.enable = true;
+  languages.python.package = pkgs.python312;
+
+  packages = with pkgs; [
+    # pipx installs the Python CLIs, see the task below. Checks are disabled
+    # because the upstream test suite currently fails to build in nixpkgs.
+    (pipx.overridePythonAttrs (_: {
+      doCheck = false;
+      doInstallCheck = false;
+    }))
+    kubectl # `kubernetes` extension
+    git # grgit / release versioning
+    openssl # Snowflake private key handling
+    jq
+  ];
+
+  # ---------------------------------------------------------------------------
+  # Environment
+  # ---------------------------------------------------------------------------
+
+  # Project-local Gradle home: keeps the build reproducible and immune to
+  # host-wide ~/.gradle/init.d scripts (e.g. corporate repository mirrors).
+  env.GRADLE_USER_HOME = "${config.env.DEVENV_STATE}/gradle";
+
+  # Extensions exercised by the test suite. Snowflake and dbt are excluded by
+  # default because they need real credentials, see the note in enterShell.
+  env.TEST_EXTENSIONS = lib.mkDefault "rabbitmq,kafka,kubernetes";
+
+  env.PIPX_HOME = "${config.env.DEVENV_STATE}/pipx";
+  env.PIPX_BIN_DIR = "${config.env.DEVENV_STATE}/pipx/bin";
+  env.PIPX_DEFAULT_PYTHON = "${pkgs.python312}/bin/python3";
+
+  # The Snowflake connector loads manylinux wheels (pyarrow) that link against
+  # libstdc++ / zlib, which are not on the default library path under Nix.
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath [
+    pkgs.stdenv.cc.cc.lib
+    pkgs.zlib
+  ];
+
+  # `.env` only carries Docker Compose settings, which Compose reads by itself.
+  dotenv.disableHint = true;
+
+  # ---------------------------------------------------------------------------
+  # Python CLIs
+  # ---------------------------------------------------------------------------
+
+  # snowflake-cli and dbt-snowflake have conflicting transitive dependencies
+  # (protobuf) and cannot share a single virtualenv, which is why the Docker
+  # images install them with `pipx install --include-deps`. Same thing here:
+  # one isolated environment per tool, requirements.txt staying the single
+  # source of truth for the versions. `--include-deps` also exposes the entry
+  # points of the dependencies, which is how `dbt` (from dbt-core) shows up.
+  tasks."karate-connect:pythonCli" = {
+    description = "Install the snowflake & dbt CLIs from requirements.txt";
+    exec = ''
+      set -euo pipefail
+      mkdir -p "$PIPX_BIN_DIR"
+      # shellcheck disable=SC2046
+      pipx install --include-deps --force $(xargs < "$DEVENV_ROOT/requirements.txt")
+    '';
+    execIfModified = [ "requirements.txt" ];
+    before = [ "devenv:enterShell" ];
+  };
+
+  # ---------------------------------------------------------------------------
+  # Scripts
+  # ---------------------------------------------------------------------------
+
+  scripts.kc-build.exec = ''
+    exec ./gradlew build -DtestExtensions="$TEST_EXTENSIONS" "$@"
+  '';
+
+  scripts.kc-build-all.exec = ''
+    exec ./gradlew build -DtestExtensions=base,rabbitmq,kafka,snowflake,dbt,kubernetes "$@"
+  '';
+
+  scripts.kc-test.exec = ''
+    exec ./gradlew test -DtestExtensions="$TEST_EXTENSIONS" "$@"
+  '';
+
+  scripts.kc-docker-build.exec = ''
+    exec docker compose build "$@"
+  '';
+
+  scripts.kc-headers.exec = ''
+    exec ./docs/headers/add-headers.sh "$@"
+  '';
+
+  # ---------------------------------------------------------------------------
+  # Hooks
+  # ---------------------------------------------------------------------------
+
+  enterShell = ''
+    export PATH="$PIPX_BIN_DIR:$PATH"
+
+    ${clearExtensionEnv}
+
+    echo "karate-connect dev environment"
+    echo "  java : $(java -version 2>&1 | head -1)"
+    echo "  snow : $(snow --version 2>/dev/null || echo 'n/a')"
+    echo "  dbt  : $(dbt --version 2>/dev/null | head -1 || echo 'n/a')"
+    echo ""
+    echo "  kc-build        fat JAR + tests on \$TEST_EXTENSIONS ($TEST_EXTENSIONS)"
+    echo "  kc-build-all    fat JAR + tests on every extension (Snowflake credentials required)"
+    echo "  kc-test         tests only"
+    echo "  kc-docker-build build the Docker images (uses the host Docker daemon)"
+    echo "  kc-headers      re-apply the license headers"
+    echo ""
+    if [ -n "$cleared" ]; then
+      echo "note: cleared inherited extension variables, which the config tests"
+      echo "      expect to be unset:$cleared"
+      echo ""
+    fi
+    if [ ! -f "$DEVENV_ROOT/src/test/resources/snowflake/snowflake.properties" ]; then
+      echo "note: src/test/resources/snowflake/snowflake.properties is missing, so the"
+      echo "      snowflake & dbt tests are skipped (TEST_EXTENSIONS=$TEST_EXTENSIONS)."
+      echo "      See src/test/resources/snowflake/snowflake.template.properties."
+      echo ""
+    fi
+    unset cleared
+  '';
+
+  # `devenv test` runs the same check as CI: fat JAR + Karate integration tests.
+  enterTest = ''
+    export PATH="$PIPX_BIN_DIR:$PATH"
+    ${clearExtensionEnv}
+    ./gradlew build -DtestExtensions="$TEST_EXTENSIONS"
+  '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = ''
+    Reusable Nix module for running karate-connect (https://github.com/lectra-tech/karate-connect)
+    Karate tests, with every setting (extensions, features path, output, tags,
+    threads, environment variables, ...) customizable. Import it from a
+    flake-parts flake (`flakeModules.default`), a plain flake
+    (`lib.mkKarateRun`), or a devenv project (`devenvModules.default`).
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Only used to dogfood/test the module against this repo's own features
+    # below. Consumers of `flakeModules.default` do NOT need flake-parts
+    # themselves; they just import the module into their own flake-parts
+    # configuration.
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      imports = [ ./nix/flake-module.nix ];
+
+      flake = {
+        # Consumer-facing outputs.
+        flakeModules.default = import ./nix/flake-module.nix;
+        devenvModules.default = import ./nix/devenv-module.nix;
+        lib.mkKarateRun = import ./nix/lib.nix;
+      };
+
+      perSystem = { config, pkgs, lib, ... }: {
+        # Dogfood the module against this repo's own, fully-mocked kubernetes
+        # feature (no real `kubectl`/network access needed: the scenario
+        # reads `mockJobDescription` instead of shelling out). This proves the
+        # whole chain end-to-end: fetching the pinned JAR, building the
+        # wrapper, and actually running Karate.
+        karate-connect.runs.kubernetes-smoke = {
+          extensions = [ "kubernetes" ];
+          featuresPath = "src/test/resources";
+          karateConfigDir = "src/test/resources";
+          tags = "@kubernetes";
+        };
+
+        checks.kubernetes-smoke = pkgs.runCommand "karate-connect-kubernetes-smoke"
+          {
+            nativeBuildInputs = [ config.packages.karate-test-kubernetes-smoke ];
+          }
+          ''
+            mkdir -p src/test
+            cp -r ${./src/test/resources} src/test/resources
+            chmod -R u+w src
+            karate-run-kubernetes-smoke
+            touch $out
+          '';
+      };
+    };
+}

--- a/nix/build-karate-run.nix
+++ b/nix/build-karate-run.nix
@@ -70,39 +70,72 @@ let
 
   javaInvocation = ''java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "${effectiveFeaturesPath}"'';
 
-  # Binding a mount directly under the *real* root (`--dev-bind / /`) would
-  # require creating that mount point on the real host filesystem, which
-  # fails with a permission error for any path the caller can't already write
-  # to (e.g. `/features`). Instead, build a fresh, writable `tmpfs` root for
-  # the sandbox and re-bind only what the JVM actually needs onto it: `/nix`
-  # (the JDK/JAR themselves), `/dev`, `/proc`, the usual DNS/locale config
-  # under `/etc` (and `/run`, since `/etc/resolv.conf` often symlinks there),
-  # `/tmp`, and the caller's own working directory (so every other relative
-  # path -- `outputDir`, `extraClasspath`, report writes, ...) keeps resolving
+  # Linux: build a fresh, writable `tmpfs` root for the sandbox and re-bind
+  # only what the JVM actually needs onto it: `/nix` (the JDK/JAR
+  # themselves), `/dev`, `/proc`, the usual DNS/locale config under `/etc`
+  # (and `/run`, since `/etc/resolv.conf` often symlinks there), `/tmp`, and
+  # the caller's own working directory (so every other relative path --
+  # `outputDir`, `extraClasspath`, report writes, ...) keeps resolving
   # exactly as it would without the sandbox). Every requested mapping is then
-  # bind-mounted on top, in one invocation. The environment (network
+  # bind-mounted on top, in one `bubblewrap` invocation. Binding a mount
+  # directly under the *real* root (`--dev-bind / /`) would instead require
+  # creating that mount point on the real host filesystem, which fails with a
+  # permission error for any path the caller can't already write to (e.g.
+  # `/features`) -- hence the synthetic root. The environment (network
   # namespace included) is otherwise left untouched, so extensions talking to
   # `localhost`/real hosts (RabbitMQ, Kafka, ...) keep working unchanged.
-  #
-  # None of the target paths may be `/` itself: that would replace (and thus
-  # hide) the base binds above rather than nest under them.
+  linuxExecLine = ''
+    bwrapArgs=(--tmpfs / --ro-bind /nix /nix --dev /dev --proc /proc --bind /tmp /tmp)
+    for d in /etc /run /var/run; do
+      if [ -e "$d" ]; then
+        bwrapArgs+=(--ro-bind "$d" "$d")
+      fi
+    done
+    bwrapArgs+=(--bind "$PWD" "$PWD")
+    ${lib.concatMapStringsSep "\n    " (m: "bwrapArgs+=(--bind ${quoted m.hostPath} ${quoted m.mountPath})") mounts}
+    exec bwrap "''${bwrapArgs[@]}" -- ${javaInvocation}'';
+
+  # macOS has no equivalent of Linux user/mount namespaces, so `bubblewrap`
+  # cannot be used there. `bindfs` (a FUSE filesystem) is used instead to
+  # perform the same bind-mount, but with two consequences the Linux path
+  # doesn't have: (1) it requires `macFUSE` to be installed and approved by
+  # the user once, outside of Nix's control (a kernel/system extension, not
+  # something this wrapper can install or consent to on the user's behalf);
+  # (2) unlike the disposable Linux sandbox, `bindfs` mounts onto the *real*
+  # filesystem, so each `mountPath` must already exist as a directory the
+  # invoking user owns (e.g. created once with
+  # `sudo mkdir -p /features && sudo chown "$(whoami)" /features`) -- this
+  # wrapper only checks for that and fails with a clear message otherwise, it
+  # does not create top-level paths itself. Every mount is unmounted again
+  # once the JVM exits (success or failure), via an `EXIT` trap; `exec` is
+  # deliberately *not* used for the `java` invocation itself so that trap
+  # still gets to run cleanup afterwards.
+  darwinExecLine = ''
+    cleanup() {
+      ${lib.concatMapStringsSep "\n      " (m: ''umount ${quoted m.mountPath} >/dev/null 2>&1 || true'') (lib.reverseList mounts)}
+    }
+    trap cleanup EXIT
+
+    ${lib.concatMapStringsSep "\n    " (m: ''
+      if [ ! -d ${quoted m.mountPath} ]; then
+        echo "karate-connect: ${quoted m.mountPath} does not exist -- pre-create it once, e.g.:" >&2
+        echo "  sudo mkdir -p ${quoted m.mountPath} && sudo chown \"\$(whoami)\" ${quoted m.mountPath}" >&2
+        exit 1
+      fi
+      bindfs ${quoted m.hostPath} ${quoted m.mountPath}'') mounts}
+
+    ${javaInvocation}'';
+
   execLine =
-    if useMounts
-    then ''
-      bwrapArgs=(--tmpfs / --ro-bind /nix /nix --dev /dev --proc /proc --bind /tmp /tmp)
-      for d in /etc /run /var/run; do
-        if [ -e "$d" ]; then
-          bwrapArgs+=(--ro-bind "$d" "$d")
-        fi
-      done
-      bwrapArgs+=(--bind "$PWD" "$PWD")
-      ${lib.concatMapStringsSep "\n      " (m: "bwrapArgs+=(--bind ${quoted m.hostPath} ${quoted m.mountPath})") mounts}
-      exec bwrap "''${bwrapArgs[@]}" -- ${javaInvocation}''
-    else "exec ${javaInvocation}";
+    if !useMounts then "exec ${javaInvocation}"
+    else if pkgs.stdenv.isLinux then linuxExecLine
+    else darwinExecLine;
 
   wrapper = pkgs.writeShellApplication {
     name = scriptName;
-    runtimeInputs = [ cfg.jdk ] ++ lib.optional useMounts pkgs.bubblewrap;
+    runtimeInputs = [ cfg.jdk ]
+      ++ lib.optional (useMounts && pkgs.stdenv.isLinux) pkgs.bubblewrap
+      ++ lib.optional (useMounts && pkgs.stdenv.isDarwin) pkgs.bindfs;
     text = ''
       ${envExports}
 
@@ -112,8 +145,8 @@ let
 in
 lib.throwIf (lib.any (m: m.hostPath == null) mounts)
   "karate-connect run '${name}': ${lib.concatMapStringsSep ", " (m: m.option) (lib.filter (m: m.hostPath == null) mounts)} set without its corresponding host path option (featuresPath/karateConfigDir)"
-  (lib.throwIf (useMounts && !pkgs.stdenv.isLinux)
-    "karate-connect run '${name}': featuresMountPath/karateConfigMountPath require bubblewrap, which is only available on Linux"
+  (lib.throwIf (useMounts && !(pkgs.stdenv.isLinux || pkgs.stdenv.isDarwin))
+    "karate-connect run '${name}': featuresMountPath/karateConfigMountPath require bubblewrap (Linux) or bindfs/macFUSE (Darwin), neither of which is available on this platform"
     (lib.throwIf (lib.any (m: m.mountPath == "/") mounts)
       "karate-connect run '${name}': featuresMountPath/karateConfigMountPath must be a real subpath, not \"/\" itself"
       {
@@ -124,3 +157,4 @@ lib.throwIf (lib.any (m: m.hostPath == null) mounts)
           meta.description = "Run karate-connect Karate tests (run '${name}')";
         };
       }))
+

--- a/nix/build-karate-run.nix
+++ b/nix/build-karate-run.nix
@@ -23,24 +23,42 @@ let
 
   quoted = s: lib.escapeShellArg s;
 
-  # Every path-like setting that can be bind-mounted onto an absolute
-  # location for the JVM, mirroring Docker's `-v <host>:<container>` mapping
-  # (e.g. `VOLUME /features`, or `-v <my-karate-config.js>:/karate-config.js`).
-  # Feature files and `karate-config.js` (or code it calls into) sometimes
-  # read auxiliary files via a hardcoded absolute path that only makes sense
-  # inside that Docker layout. `bind` pairs are collected here so a single
-  # `bubblewrap` invocation can perform every requested mapping at once.
+  platform =
+    if pkgs.stdenv.isLinux then "linux"
+    else if pkgs.stdenv.isDarwin then "darwin"
+    else "unsupported";
+
+  ## -- 1. Bind-mount settings & validation -----------------------------------
+  # Every path-like setting that can be bind-mounted onto an absolute location
+  # for the JVM, mirroring Docker's `-v <host>:<container>` mapping. See
+  # `featuresMountPath`/`karateConfigMountPath` in karate-run-options.nix for
+  # the full rationale, platform support and caveats.
   mounts = lib.filter (m: m.mountPath != null) [
     { hostPath = cfg.featuresPath; mountPath = cfg.featuresMountPath; option = "featuresMountPath"; }
     { hostPath = cfg.karateConfigDir; mountPath = cfg.karateConfigMountPath; option = "karateConfigMountPath"; }
   ];
   useMounts = mounts != [ ];
 
-  # Each path as seen by the JVM: either the plain host path, or the absolute
-  # mount point it has been bind-mounted onto.
-  effectiveFeaturesPath = if cfg.featuresMountPath != null then cfg.featuresMountPath else cfg.featuresPath;
-  effectiveKarateConfigDir = if cfg.karateConfigMountPath != null then cfg.karateConfigMountPath else cfg.karateConfigDir;
+  missingHostPath = lib.filter (m: m.hostPath == null) mounts;
 
+  # Collected up front so evaluation fails once, with every problem reported
+  # together, instead of nested `throwIf`s wrapping the final result.
+  errors =
+    lib.optional (missingHostPath != [ ])
+      "karate-connect run '${name}': ${lib.concatMapStringsSep ", " (m: m.option) missingHostPath} set without its corresponding host path option (featuresPath/karateConfigDir)"
+    ++ lib.optional (useMounts && platform == "unsupported")
+      "karate-connect run '${name}': featuresMountPath/karateConfigMountPath require bubblewrap (Linux) or bindfs/macFUSE (Darwin), neither of which is available on this platform"
+    ++ lib.optional (lib.any (m: m.mountPath == "/") mounts)
+      "karate-connect run '${name}': featuresMountPath/karateConfigMountPath must be a real subpath, not \"/\" itself";
+
+  ## -- 2. Effective paths, as seen by the JVM --------------------------------
+  # Either the plain host path, or the absolute mount point it has been
+  # bind-mounted onto.
+  effectivePath = hostPath: mountPath: if mountPath != null then mountPath else hostPath;
+  effectiveFeaturesPath = effectivePath cfg.featuresPath cfg.featuresMountPath;
+  effectiveKarateConfigDir = effectivePath cfg.karateConfigDir cfg.karateConfigMountPath;
+
+  ## -- 3. Classpath, JVM & Karate CLI arguments -------------------------------
   envExports = lib.concatStringsSep "\n" (
     lib.mapAttrsToList (k: v: "export ${k}=${quoted v}") cfg.environmentVariables
   );
@@ -87,20 +105,12 @@ let
 
   javaInvocation = ''java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "''${featureArgs[@]}"'';
 
-  # Linux: build a fresh, writable `tmpfs` root for the sandbox and re-bind
-  # only what the JVM actually needs onto it: `/nix` (the JDK/JAR
-  # themselves), `/dev`, `/proc`, the usual DNS/locale config under `/etc`
-  # (and `/run`, since `/etc/resolv.conf` often symlinks there), `/tmp`, and
-  # the caller's own working directory (so every other relative path --
-  # `outputDir`, `extraClasspath`, report writes, ...) keeps resolving
-  # exactly as it would without the sandbox). Every requested mapping is then
-  # bind-mounted on top, in one `bubblewrap` invocation. Binding a mount
-  # directly under the *real* root (`--dev-bind / /`) would instead require
-  # creating that mount point on the real host filesystem, which fails with a
-  # permission error for any path the caller can't already write to (e.g.
-  # `/features`) -- hence the synthetic root. The environment (network
-  # namespace included) is otherwise left untouched, so extensions talking to
-  # `localhost`/real hosts (RabbitMQ, Kafka, ...) keep working unchanged.
+  ## -- 4. Platform-specific exec line -----------------------------------------
+  # Builds a fresh, writable sandbox root and re-binds only what the JVM
+  # needs (`/nix`, `/dev`, `/proc`, `/etc`/`/run`, `/tmp`, and the caller's
+  # working directory) before bind-mounting every requested mapping on top,
+  # in one `bubblewrap` invocation. See `featuresMountPath` in
+  # karate-run-options.nix for the full rationale and caveats.
   linuxExecLine = ''
     bwrapArgs=(--tmpfs / --ro-bind /nix /nix --dev /dev --proc /proc --bind /tmp /tmp)
     for d in /etc /run /var/run; do
@@ -112,21 +122,13 @@ let
     ${lib.concatMapStringsSep "\n    " (m: "bwrapArgs+=(--bind ${quoted m.hostPath} ${quoted m.mountPath})") mounts}
     exec bwrap "''${bwrapArgs[@]}" -- ${javaInvocation}'';
 
-  # macOS has no equivalent of Linux user/mount namespaces, so `bubblewrap`
-  # cannot be used there. `bindfs` (a FUSE filesystem) is used instead to
-  # perform the same bind-mount, but with two consequences the Linux path
-  # doesn't have: (1) it requires `macFUSE` to be installed and approved by
-  # the user once, outside of Nix's control (a kernel/system extension, not
-  # something this wrapper can install or consent to on the user's behalf);
-  # (2) unlike the disposable Linux sandbox, `bindfs` mounts onto the *real*
-  # filesystem, so each `mountPath` must already exist as a directory the
-  # invoking user owns (e.g. created once with
-  # `sudo mkdir -p /features && sudo chown "$(whoami)" /features`) -- this
-  # wrapper only checks for that and fails with a clear message otherwise, it
-  # does not create top-level paths itself. Every mount is unmounted again
-  # once the JVM exits (success or failure), via an `EXIT` trap; `exec` is
-  # deliberately *not* used for the `java` invocation itself so that trap
-  # still gets to run cleanup afterwards.
+  # No Linux-style sandbox exists on Darwin, so `bindfs` (a FUSE filesystem)
+  # performs the same bind-mount directly on the real filesystem instead.
+  # Each `mountPath` must already exist and be owned by the invoking user
+  # (checked below, with a clear error otherwise); mounts are undone via an
+  # `EXIT` trap, so `exec` is deliberately *not* used for the `java`
+  # invocation itself. See `featuresMountPath` in karate-run-options.nix for
+  # the full rationale and caveats.
   darwinExecLine = ''
     cleanup() {
       ${lib.concatMapStringsSep "\n      " (m: ''umount ${quoted m.mountPath} >/dev/null 2>&1 || true'') (lib.reverseList mounts)}
@@ -143,16 +145,15 @@ let
 
     ${javaInvocation}'';
 
-  execLine =
-    if !useMounts then "exec ${javaInvocation}"
-    else if pkgs.stdenv.isLinux then linuxExecLine
-    else darwinExecLine;
+  platformExecLine = if platform == "linux" then linuxExecLine else darwinExecLine;
+  execLine = if useMounts then platformExecLine else "exec ${javaInvocation}";
 
-  wrapper = pkgs.writeShellApplication {
+  ## -- 5. Wrapper derivation ---------------------------------------------------
+  package = pkgs.writeShellApplication {
     name = scriptName;
     runtimeInputs = [ cfg.jdk ]
-      ++ lib.optional (useMounts && pkgs.stdenv.isLinux) pkgs.bubblewrap
-      ++ lib.optional (useMounts && pkgs.stdenv.isDarwin) pkgs.bindfs;
+      ++ lib.optional (useMounts && platform == "linux") pkgs.bubblewrap
+      ++ lib.optional (useMounts && platform == "darwin") pkgs.bindfs;
     text = ''
       ${envExports}
 
@@ -161,18 +162,15 @@ let
     '';
   };
 in
-lib.throwIf (lib.any (m: m.hostPath == null) mounts)
-  "karate-connect run '${name}': ${lib.concatMapStringsSep ", " (m: m.option) (lib.filter (m: m.hostPath == null) mounts)} set without its corresponding host path option (featuresPath/karateConfigDir)"
-  (lib.throwIf (useMounts && !(pkgs.stdenv.isLinux || pkgs.stdenv.isDarwin))
-    "karate-connect run '${name}': featuresMountPath/karateConfigMountPath require bubblewrap (Linux) or bindfs/macFUSE (Darwin), neither of which is available on this platform"
-    (lib.throwIf (lib.any (m: m.mountPath == "/") mounts)
-      "karate-connect run '${name}': featuresMountPath/karateConfigMountPath must be a real subpath, not \"/\" itself"
-      {
-        package = wrapper;
-        app = {
-          type = "app";
-          program = "${wrapper}/bin/${scriptName}";
-          meta.description = "Run karate-connect Karate tests (run '${name}')";
-        };
-      }))
+if errors != [ ] then
+  throw (lib.concatStringsSep "\n" errors)
+else
+  {
+    inherit package;
+    app = {
+      type = "app";
+      program = "${package}/bin/${scriptName}";
+      meta.description = "Run karate-connect Karate tests (run '${name}')";
+    };
+  }
 

--- a/nix/build-karate-run.nix
+++ b/nix/build-karate-run.nix
@@ -68,7 +68,24 @@ let
     ++ map quoted cfg.extraArgs
   );
 
-  javaInvocation = ''java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "${effectiveFeaturesPath}"'';
+  # Mirrors the Docker image's own `entrypoint.sh` (`java ... $@`, with
+  # `CMD ["features"]` as the default): calling the wrapper with no arguments
+  # runs the configured `featuresPath` (or its mount-mapped equivalent), and
+  # calling it with one or more arguments (e.g. `karate-default
+  # src/test/features/foo.feature`) replaces it entirely -- only the given
+  # path(s) run, exactly like `docker run <image> <args>` overrides `CMD`
+  # rather than adding to it. `classpath` is unaffected either way, so
+  # `classpath:...`-relative resource resolution keeps working even when a
+  # single feature file outside `featuresPath` is targeted.
+  featureArgsSnippet = ''
+    if [ "$#" -gt 0 ]; then
+      featureArgs=("$@")
+    else
+      featureArgs=(${quoted effectiveFeaturesPath})
+    fi
+  '';
+
+  javaInvocation = ''java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "''${featureArgs[@]}"'';
 
   # Linux: build a fresh, writable `tmpfs` root for the sandbox and re-bind
   # only what the JVM actually needs onto it: `/nix` (the JDK/JAR
@@ -139,6 +156,7 @@ let
     text = ''
       ${envExports}
 
+      ${featureArgsSnippet}
       ${execLine}
     '';
   };

--- a/nix/build-karate-run.nix
+++ b/nix/build-karate-run.nix
@@ -1,0 +1,70 @@
+# Pure builder: turns one evaluated `karate-run-options.nix` config into a
+# runnable wrapper script + a flake `app`. Shared by every adapter
+# (flake-parts, plain `lib.mkKarateRun`, devenv) so their behavior never
+# diverges.
+#
+# All path-like settings (featuresPath, karateConfigDir, outputDir,
+# extraClasspath) are kept as plain strings and expanded by the wrapper *at
+# run time*, so they resolve relative to the caller's current working
+# directory (e.g. a consumer project's checkout) rather than being copied
+# into the Nix store.
+#
+# The JAR is put on an explicit `-cp` (rather than run with `-jar`) together
+# with `featuresPath`/`karateConfigDir`/`extraClasspath`, and
+# `com.intuit.karate.Main` (the JAR's own `Main-Class`) is invoked directly.
+# This is required so that `classpath:...` reads inside feature files (e.g.
+# mock JSON fixtures colocated with the tests) can find files that live on
+# disk next to the consumer's features rather than inside the JAR — `-jar`
+# alone ignores any classpath entry besides the JAR itself.
+{ pkgs, lib, name, cfg }:
+
+let
+  scriptName = "karate-run-${name}";
+
+  quoted = s: lib.escapeShellArg s;
+
+  envExports = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (k: v: "export ${k}=${quoted v}") cfg.environmentVariables
+  );
+
+  classpathEntries = lib.unique (
+    [ "${cfg.jar}" cfg.featuresPath ]
+    ++ lib.optional (cfg.karateConfigDir != null) cfg.karateConfigDir
+    ++ cfg.extraClasspath
+  );
+  classpath = lib.concatStringsSep ":" classpathEntries;
+
+  javaArgs = lib.concatStringsSep " " (
+    [ "-Dextensions=${lib.concatStringsSep "," cfg.extensions}" ]
+    ++ lib.optional (cfg.karateConfigDir != null) ''-Dkarate.config.dir="${cfg.karateConfigDir}"''
+    ++ map quoted cfg.jvmArgs
+  );
+
+  karateArgs = lib.concatStringsSep " " (
+    [ "-T" (toString cfg.threads) ]
+    ++ [ "-o" (quoted cfg.outputDir) ]
+    ++ [ "-f" (quoted (lib.concatStringsSep "," cfg.format)) ]
+    ++ lib.optionals (cfg.tags != null) [ "-t" (quoted cfg.tags) ]
+    ++ lib.optionals (cfg.env != null) [ "-e" (quoted cfg.env) ]
+    ++ lib.optionals (cfg.name != null) [ "-n" (quoted cfg.name) ]
+    ++ map quoted cfg.extraArgs
+  );
+
+  wrapper = pkgs.writeShellApplication {
+    name = scriptName;
+    runtimeInputs = [ cfg.jdk ];
+    text = ''
+      ${envExports}
+
+      exec java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "${cfg.featuresPath}"
+    '';
+  };
+in
+{
+  package = wrapper;
+  app = {
+    type = "app";
+    program = "${wrapper}/bin/${scriptName}";
+    meta.description = "Run karate-connect Karate tests (run '${name}')";
+  };
+}

--- a/nix/build-karate-run.nix
+++ b/nix/build-karate-run.nix
@@ -23,17 +23,23 @@ let
 
   quoted = s: lib.escapeShellArg s;
 
-  # `cfg.featuresMountPath` mirrors Docker's `-v <features_path>:/features`:
-  # some feature files read fixtures via a hardcoded absolute path that only
-  # makes sense inside that Docker layout (e.g. `read('/features/foo.json')`).
-  # When set, `bubblewrap` bind-mounts `cfg.featuresPath` onto that absolute
-  # path for the JVM's mount namespace only -- no Nix store copy, no change
-  # to the real filesystem outside the wrapped process.
-  useFeaturesMount = cfg.featuresMountPath != null;
+  # Every path-like setting that can be bind-mounted onto an absolute
+  # location for the JVM, mirroring Docker's `-v <host>:<container>` mapping
+  # (e.g. `VOLUME /features`, or `-v <my-karate-config.js>:/karate-config.js`).
+  # Feature files and `karate-config.js` (or code it calls into) sometimes
+  # read auxiliary files via a hardcoded absolute path that only makes sense
+  # inside that Docker layout. `bind` pairs are collected here so a single
+  # `bubblewrap` invocation can perform every requested mapping at once.
+  mounts = lib.filter (m: m.mountPath != null) [
+    { hostPath = cfg.featuresPath; mountPath = cfg.featuresMountPath; option = "featuresMountPath"; }
+    { hostPath = cfg.karateConfigDir; mountPath = cfg.karateConfigMountPath; option = "karateConfigMountPath"; }
+  ];
+  useMounts = mounts != [ ];
 
-  # `featuresPath` as seen by the JVM: either the plain path, or the absolute
+  # Each path as seen by the JVM: either the plain host path, or the absolute
   # mount point it has been bind-mounted onto.
-  effectiveFeaturesPath = if useFeaturesMount then cfg.featuresMountPath else cfg.featuresPath;
+  effectiveFeaturesPath = if cfg.featuresMountPath != null then cfg.featuresMountPath else cfg.featuresPath;
+  effectiveKarateConfigDir = if cfg.karateConfigMountPath != null then cfg.karateConfigMountPath else cfg.karateConfigDir;
 
   envExports = lib.concatStringsSep "\n" (
     lib.mapAttrsToList (k: v: "export ${k}=${quoted v}") cfg.environmentVariables
@@ -41,14 +47,14 @@ let
 
   classpathEntries = lib.unique (
     [ "${cfg.jar}" effectiveFeaturesPath ]
-    ++ lib.optional (cfg.karateConfigDir != null) cfg.karateConfigDir
+    ++ lib.optional (effectiveKarateConfigDir != null) effectiveKarateConfigDir
     ++ cfg.extraClasspath
   );
   classpath = lib.concatStringsSep ":" classpathEntries;
 
   javaArgs = lib.concatStringsSep " " (
     [ "-Dextensions=${lib.concatStringsSep "," cfg.extensions}" ]
-    ++ lib.optional (cfg.karateConfigDir != null) ''-Dkarate.config.dir="${cfg.karateConfigDir}"''
+    ++ lib.optional (effectiveKarateConfigDir != null) ''-Dkarate.config.dir="${effectiveKarateConfigDir}"''
     ++ map quoted cfg.jvmArgs
   );
 
@@ -64,21 +70,24 @@ let
 
   javaInvocation = ''java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "${effectiveFeaturesPath}"'';
 
-  # Binding `featuresMountPath` directly under the *real* root (`--dev-bind /
-  # /`) would require creating that mount point on the real host filesystem,
-  # which fails with a permission error for any path the caller can't already
-  # write to (e.g. `/features`). Instead, build a fresh, writable `tmpfs` root
-  # for the sandbox and re-bind only what the JVM actually needs onto it:
-  # `/nix` (the JDK/JAR themselves), `/dev`, `/proc`, the usual DNS/locale
-  # config under `/etc` (and `/run`, since `/etc/resolv.conf` often symlinks
-  # there), `/tmp`, and the caller's own working directory (so every other
-  # relative path -- `outputDir`, `karateConfigDir`, `extraClasspath`, report
-  # writes, ...) keeps resolving exactly as it would without the sandbox).
-  # The environment (network namespace included) is otherwise left untouched,
-  # so extensions talking to `localhost`/real hosts (RabbitMQ, Kafka, ...)
-  # keep working unchanged.
+  # Binding a mount directly under the *real* root (`--dev-bind / /`) would
+  # require creating that mount point on the real host filesystem, which
+  # fails with a permission error for any path the caller can't already write
+  # to (e.g. `/features`). Instead, build a fresh, writable `tmpfs` root for
+  # the sandbox and re-bind only what the JVM actually needs onto it: `/nix`
+  # (the JDK/JAR themselves), `/dev`, `/proc`, the usual DNS/locale config
+  # under `/etc` (and `/run`, since `/etc/resolv.conf` often symlinks there),
+  # `/tmp`, and the caller's own working directory (so every other relative
+  # path -- `outputDir`, `extraClasspath`, report writes, ...) keeps resolving
+  # exactly as it would without the sandbox). Every requested mapping is then
+  # bind-mounted on top, in one invocation. The environment (network
+  # namespace included) is otherwise left untouched, so extensions talking to
+  # `localhost`/real hosts (RabbitMQ, Kafka, ...) keep working unchanged.
+  #
+  # None of the target paths may be `/` itself: that would replace (and thus
+  # hide) the base binds above rather than nest under them.
   execLine =
-    if useFeaturesMount
+    if useMounts
     then ''
       bwrapArgs=(--tmpfs / --ro-bind /nix /nix --dev /dev --proc /proc --bind /tmp /tmp)
       for d in /etc /run /var/run; do
@@ -87,13 +96,13 @@ let
         fi
       done
       bwrapArgs+=(--bind "$PWD" "$PWD")
-      bwrapArgs+=(--bind ${quoted cfg.featuresPath} ${quoted cfg.featuresMountPath})
+      ${lib.concatMapStringsSep "\n      " (m: "bwrapArgs+=(--bind ${quoted m.hostPath} ${quoted m.mountPath})") mounts}
       exec bwrap "''${bwrapArgs[@]}" -- ${javaInvocation}''
     else "exec ${javaInvocation}";
 
   wrapper = pkgs.writeShellApplication {
     name = scriptName;
-    runtimeInputs = [ cfg.jdk ] ++ lib.optional useFeaturesMount pkgs.bubblewrap;
+    runtimeInputs = [ cfg.jdk ] ++ lib.optional useMounts pkgs.bubblewrap;
     text = ''
       ${envExports}
 
@@ -101,13 +110,17 @@ let
     '';
   };
 in
-lib.throwIf (useFeaturesMount && !pkgs.stdenv.isLinux)
-  "karate-connect run '${name}': featuresMountPath requires bubblewrap, which is only available on Linux"
-{
-  package = wrapper;
-  app = {
-    type = "app";
-    program = "${wrapper}/bin/${scriptName}";
-    meta.description = "Run karate-connect Karate tests (run '${name}')";
-  };
-}
+lib.throwIf (lib.any (m: m.hostPath == null) mounts)
+  "karate-connect run '${name}': ${lib.concatMapStringsSep ", " (m: m.option) (lib.filter (m: m.hostPath == null) mounts)} set without its corresponding host path option (featuresPath/karateConfigDir)"
+  (lib.throwIf (useMounts && !pkgs.stdenv.isLinux)
+    "karate-connect run '${name}': featuresMountPath/karateConfigMountPath require bubblewrap, which is only available on Linux"
+    (lib.throwIf (lib.any (m: m.mountPath == "/") mounts)
+      "karate-connect run '${name}': featuresMountPath/karateConfigMountPath must be a real subpath, not \"/\" itself"
+      {
+        package = wrapper;
+        app = {
+          type = "app";
+          program = "${wrapper}/bin/${scriptName}";
+          meta.description = "Run karate-connect Karate tests (run '${name}')";
+        };
+      }))

--- a/nix/build-karate-run.nix
+++ b/nix/build-karate-run.nix
@@ -23,12 +23,24 @@ let
 
   quoted = s: lib.escapeShellArg s;
 
+  # `cfg.featuresMountPath` mirrors Docker's `-v <features_path>:/features`:
+  # some feature files read fixtures via a hardcoded absolute path that only
+  # makes sense inside that Docker layout (e.g. `read('/features/foo.json')`).
+  # When set, `bubblewrap` bind-mounts `cfg.featuresPath` onto that absolute
+  # path for the JVM's mount namespace only -- no Nix store copy, no change
+  # to the real filesystem outside the wrapped process.
+  useFeaturesMount = cfg.featuresMountPath != null;
+
+  # `featuresPath` as seen by the JVM: either the plain path, or the absolute
+  # mount point it has been bind-mounted onto.
+  effectiveFeaturesPath = if useFeaturesMount then cfg.featuresMountPath else cfg.featuresPath;
+
   envExports = lib.concatStringsSep "\n" (
     lib.mapAttrsToList (k: v: "export ${k}=${quoted v}") cfg.environmentVariables
   );
 
   classpathEntries = lib.unique (
-    [ "${cfg.jar}" cfg.featuresPath ]
+    [ "${cfg.jar}" effectiveFeaturesPath ]
     ++ lib.optional (cfg.karateConfigDir != null) cfg.karateConfigDir
     ++ cfg.extraClasspath
   );
@@ -50,16 +62,47 @@ let
     ++ map quoted cfg.extraArgs
   );
 
+  javaInvocation = ''java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "${effectiveFeaturesPath}"'';
+
+  # Binding `featuresMountPath` directly under the *real* root (`--dev-bind /
+  # /`) would require creating that mount point on the real host filesystem,
+  # which fails with a permission error for any path the caller can't already
+  # write to (e.g. `/features`). Instead, build a fresh, writable `tmpfs` root
+  # for the sandbox and re-bind only what the JVM actually needs onto it:
+  # `/nix` (the JDK/JAR themselves), `/dev`, `/proc`, the usual DNS/locale
+  # config under `/etc` (and `/run`, since `/etc/resolv.conf` often symlinks
+  # there), `/tmp`, and the caller's own working directory (so every other
+  # relative path -- `outputDir`, `karateConfigDir`, `extraClasspath`, report
+  # writes, ...) keeps resolving exactly as it would without the sandbox).
+  # The environment (network namespace included) is otherwise left untouched,
+  # so extensions talking to `localhost`/real hosts (RabbitMQ, Kafka, ...)
+  # keep working unchanged.
+  execLine =
+    if useFeaturesMount
+    then ''
+      bwrapArgs=(--tmpfs / --ro-bind /nix /nix --dev /dev --proc /proc --bind /tmp /tmp)
+      for d in /etc /run /var/run; do
+        if [ -e "$d" ]; then
+          bwrapArgs+=(--ro-bind "$d" "$d")
+        fi
+      done
+      bwrapArgs+=(--bind "$PWD" "$PWD")
+      bwrapArgs+=(--bind ${quoted cfg.featuresPath} ${quoted cfg.featuresMountPath})
+      exec bwrap "''${bwrapArgs[@]}" -- ${javaInvocation}''
+    else "exec ${javaInvocation}";
+
   wrapper = pkgs.writeShellApplication {
     name = scriptName;
-    runtimeInputs = [ cfg.jdk ];
+    runtimeInputs = [ cfg.jdk ] ++ lib.optional useFeaturesMount pkgs.bubblewrap;
     text = ''
       ${envExports}
 
-      exec java ${javaArgs} -cp "${classpath}" com.intuit.karate.Main ${karateArgs} "${cfg.featuresPath}"
+      ${execLine}
     '';
   };
 in
+lib.throwIf (useFeaturesMount && !pkgs.stdenv.isLinux)
+  "karate-connect run '${name}': featuresMountPath requires bubblewrap, which is only available on Linux"
 {
   package = wrapper;
   app = {

--- a/nix/default-jar.nix
+++ b/nix/default-jar.nix
@@ -1,0 +1,22 @@
+# Pinned, reproducible fetch of a published karate-connect standalone JAR from
+# GitHub Releases (https://github.com/lectra-tech/karate-connect/releases).
+#
+# karate-connect itself is a Gradle/Kotlin project; this flake does not try to
+# rebuild it from source (fragile & slow under Nix). Instead it fetches the
+# already-published fat JAR and pins it by content hash, exactly like the
+# project's own Docker images do (`karate-connect-<version>-standalone.jar`).
+#
+# Usage:
+#   import ./default-jar.nix { inherit pkgs; }
+# or, to pin a different release:
+#   import ./default-jar.nix { inherit pkgs; version = "0.5.2"; hash = "sha256-..."; }
+{ pkgs
+, version ? "0.5.3"
+, hash ? "sha256-gjOjHqTpeIv5jI5EK8l8Yw89b/PO7QwjgrLiKxrYjh0="
+}:
+
+pkgs.fetchurl {
+  name = "karate-connect-${version}-standalone.jar";
+  url = "https://github.com/lectra-tech/karate-connect/releases/download/v${version}/karate-connect-${version}-standalone.jar";
+  inherit hash;
+}

--- a/nix/devenv-module.nix
+++ b/nix/devenv-module.nix
@@ -1,0 +1,51 @@
+# devenv adapter: exposes `karate-connect.runs.<name>` options at the top of a
+# consumer's `devenv.nix`, wiring each run's JDK/JAR into `packages` and
+# adding a `karate-<name>` script that invokes the Karate CLI.
+#
+# Usage in a consumer's devenv.yaml:
+#
+#   inputs:
+#     karate-connect:
+#       url: github:lectra-tech/karate-connect
+#
+# and devenv.nix:
+#
+#   { inputs, ... }:
+#   {
+#     imports = [ inputs.karate-connect.devenvModules.default ];
+#     karate-connect.runs.default = {
+#       extensions = [ "rabbitmq" "kafka" ];
+#       featuresPath = "src/test/features";
+#     };
+#   }
+#
+#   $ devenv shell -- karate-default
+{ pkgs, lib, config, ... }:
+
+let
+  built = lib.mapAttrs
+    (name: cfg: import ./build-karate-run.nix { inherit pkgs lib name cfg; })
+    config.karate-connect.runs;
+in
+{
+  options.karate-connect.runs = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submoduleWith {
+      modules = [ (import ./karate-run-options.nix) ];
+      specialArgs = { inherit pkgs; };
+    });
+    default = { };
+    description = ''
+      Named karate-connect test runs. Each entry adds a `karate-<name>`
+      script to the devenv shell that invokes the karate-connect JAR with the
+      given settings.
+    '';
+  };
+
+  config = {
+    # No extra `packages` entry needed: `writeShellApplication` already wraps
+    # each script with its own `jdk` on PATH (via `runtimeInputs`).
+    scripts = lib.mapAttrs'
+      (name: b: lib.nameValuePair "karate-${name}" { exec = ''exec ${b.package}/bin/karate-run-${name} "$@"''; })
+      built;
+  };
+}

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,0 +1,48 @@
+# flake-parts adapter: exposes `perSystem.karate-connect.runs.<name>` options
+# and, for each entry, a package + app named `karate-test-<name>` that runs
+# karate-connect's Karate CLI with that configuration.
+#
+# Usage in a consumer flake:
+#
+#   { inputs, ... }:
+#   {
+#     imports = [ inputs.karate-connect.flakeModules.default ];
+#     perSystem = { ... }: {
+#       karate-connect.runs.default = {
+#         extensions = [ "rabbitmq" "kafka" ];
+#         featuresPath = "src/test/features";
+#         environmentVariables.RABBITMQ_HOST = "localhost";
+#       };
+#     };
+#   }
+#
+#   $ nix run .#karate-test-default
+{ lib, ... }:
+
+{
+  perSystem = { config, pkgs, lib, ... }:
+    let
+      built = lib.mapAttrs
+        (name: cfg: import ./build-karate-run.nix { inherit pkgs lib name cfg; })
+        config.karate-connect.runs;
+    in
+    {
+      options.karate-connect.runs = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.submoduleWith {
+          modules = [ (import ./karate-run-options.nix) ];
+          specialArgs = { inherit pkgs; };
+        });
+        default = { };
+        description = ''
+          Named karate-connect test runs. Each entry produces a package and
+          app named `karate-test-<name>` that invokes the karate-connect JAR
+          with the given settings.
+        '';
+      };
+
+      config = {
+        packages = lib.mapAttrs' (name: b: lib.nameValuePair "karate-test-${name}" b.package) built;
+        apps = lib.mapAttrs' (name: b: lib.nameValuePair "karate-test-${name}" b.app) built;
+      };
+    };
+}

--- a/nix/karate-run-options.nix
+++ b/nix/karate-run-options.nix
@@ -61,9 +61,11 @@ in
       example = "/features";
       description = ''
         Absolute path at which `featuresPath` should appear to the running
-        JVM, bind-mounted at run time via `bubblewrap` (`bwrap`) -- the same
-        remapping Docker usage does with `-v <features_path>:/features` (see
-        the Docker image's `VOLUME /features`).
+        JVM, bind-mounted at run time -- the same remapping Docker usage does
+        with `-v <features_path>:/features` (see the Docker image's
+        `VOLUME /features`). Implemented with `bubblewrap` (`bwrap`) on Linux,
+        or `bindfs` on Darwin (see below); evaluation fails with a clear error
+        on any other platform.
 
         Feature files are sometimes written to read fixtures via a hardcoded
         absolute path (e.g. `read('/features/foo.json')`) that only makes
@@ -74,15 +76,26 @@ in
         without copying anything into the Nix store.
 
         Leave `null` (the default) to run the JVM directly against
-        `featuresPath`, with no remapping. Only supported on Linux
-        (`bubblewrap` is not available on Darwin); evaluation fails with a
-        clear error if set on a non-Linux system.
+        `featuresPath`, with no remapping.
 
-        Must be a real subpath (e.g. `/features`), not `/` itself: the sandbox
-        works by building one fresh, writable root and re-binding `/nix`,
-        `/dev`, `/proc`, `/etc`, `/run`, `/tmp` and the caller's working
-        directory back onto it, so mounting something else directly onto `/`
-        would hide those.
+        On Linux: must be a real subpath (e.g. `/features`), not `/` itself --
+        the sandbox works by building one fresh, writable root and
+        re-binding `/nix`, `/dev`, `/proc`, `/etc`, `/run`, `/tmp` and the
+        caller's working directory back onto it, so mounting something else
+        directly onto `/` would hide those.
+
+        On Darwin: there is no namespace-based sandbox equivalent to
+        `bubblewrap`, so `bindfs` (a FUSE filesystem) is used instead, with
+        two consequences: (1) it requires `macFUSE` to be installed and
+        approved by the user once -- a system extension outside of Nix's
+        control, this option cannot install or consent to it for you; (2)
+        unlike the disposable Linux sandbox, `bindfs` mounts onto the *real*
+        filesystem, so `featuresMountPath` must already exist as a directory
+        the invoking user owns (e.g. created once with
+        `sudo mkdir -p /features && sudo chown "$(whoami)" /features`) --
+        evaluation succeeds either way, but the run fails at execution time
+        with a clear message if the directory is missing. This Darwin path is
+        less exercised than the Linux one; treat it as best-effort.
       '';
     };
 
@@ -104,8 +117,12 @@ in
       example = "/karate-config";
       description = ''
         Absolute path at which `karateConfigDir` should appear to the running
-        JVM, bind-mounted at run time via `bubblewrap` (`bwrap`) -- the same
-        remapping Docker usage does with `-v <my-specific-karate-config.js>:/karate-config.js`.
+        JVM, bind-mounted at run time -- the same remapping Docker usage does
+        with `-v <my-specific-karate-config.js>:/karate-config.js`.
+        Implemented the same way as `featuresMountPath` (`bubblewrap` on
+        Linux, `bindfs` on Darwin, with the same Darwin caveats: manual
+        `macFUSE` setup, and the target directory must already exist and be
+        owned by the invoking user).
 
         `karate-config.js` (or code it calls into) sometimes reads auxiliary
         files via a hardcoded absolute path that only makes sense inside that
@@ -118,11 +135,9 @@ in
         without copying anything into the Nix store.
 
         Leave `null` (the default) to run the JVM directly against
-        `karateConfigDir`, with no remapping. Only supported on Linux
-        (`bubblewrap` is not available on Darwin); evaluation fails with a
-        clear error if set on a non-Linux system. Must be a real subpath (e.g.
-        `/karate-config`), not `/` itself, for the same reason as
-        `featuresMountPath`.
+        `karateConfigDir`, with no remapping. Requires `karateConfigDir` to
+        also be set. Must be a real subpath (e.g. `/karate-config`), not `/`
+        itself, for the same reason as `featuresMountPath`.
       '';
     };
 

--- a/nix/karate-run-options.nix
+++ b/nix/karate-run-options.nix
@@ -37,8 +37,8 @@ in
     };
 
     extensions = mkOption {
-      type = types.listOf (types.enum [ "base" "rabbitmq" "kafka" "snowflake" "dbt" "kubernetes" ]);
-      default = [ "base" ];
+      type = types.listOf (types.enum [ "rabbitmq" "kafka" "snowflake" "dbt" "kubernetes" ]);
+      default = [ ];
       description = ''
         Extensions to load, passed as `-Dextensions=<ext1>,<ext2>,...`. `base`
         is always loaded by karate-connect itself regardless of this list.

--- a/nix/karate-run-options.nix
+++ b/nix/karate-run-options.nix
@@ -1,0 +1,151 @@
+# Shared option set describing a single "karate-connect run": what JAR to use,
+# which extensions to load, where the features/config/output live, and how to
+# invoke the Karate CLI. Every consumer-facing adapter (flake-parts module,
+# plain `lib.mkKarateRun`, devenv module) wraps *this exact* module as a
+# `types.submodule`, so the three integration styles can never drift apart.
+#
+# Intended usage: `lib.types.submodule (import ./karate-run-options.nix)`
+# evaluated with `pkgs` and the attribute `name` available as module args
+# (flake-parts, devenv and `lib.evalModules` all provide both).
+{ lib, pkgs, name ? "default", ... }:
+
+let
+  inherit (lib) types mkOption;
+  defaultJar = import ./default-jar.nix { inherit pkgs; };
+in
+{
+  options = {
+    jar = mkOption {
+      type = types.package;
+      default = defaultJar;
+      defaultText = lib.literalExpression ''import ./default-jar.nix { inherit pkgs; }'';
+      description = ''
+        The karate-connect standalone JAR to run. Defaults to a pinned release
+        fetched from GitHub Releases. Override with a custom build (e.g. a
+        fork, or a locally built `-standalone.jar`) if needed.
+      '';
+    };
+
+    jdk = mkOption {
+      type = types.package;
+      default = pkgs.temurin-bin-21;
+      defaultText = lib.literalExpression "pkgs.temurin-bin-21";
+      description = ''
+        JDK used to run the JAR. Defaults to JDK 21, matching karate-connect's
+        own Gradle toolchain and Docker builder image.
+      '';
+    };
+
+    extensions = mkOption {
+      type = types.listOf (types.enum [ "base" "rabbitmq" "kafka" "snowflake" "dbt" "kubernetes" ]);
+      default = [ "base" ];
+      description = ''
+        Extensions to load, passed as `-Dextensions=<ext1>,<ext2>,...`. `base`
+        is always loaded by karate-connect itself regardless of this list.
+      '';
+    };
+
+    featuresPath = mkOption {
+      type = types.str;
+      default = "features";
+      description = ''
+        Path to the feature file(s) or directory to run, resolved at runtime
+        against the invoking shell's working directory (kept as a plain
+        string, not a Nix path, so it is never copied into the store).
+      '';
+    };
+
+    karateConfigDir = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = ".";
+      description = ''
+        Directory containing a custom `karate-config.js`, passed as
+        `-Dkarate.config.dir=<dir>`. Resolved at runtime against the invoking
+        shell's working directory. Leave `null` to use Karate's default
+        resolution (classpath / current directory).
+      '';
+    };
+
+    outputDir = mkOption {
+      type = types.str;
+      default = "target/karate-reports";
+      description = "Report output directory, passed as `-o`.";
+    };
+
+    tags = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "@smoke";
+      description = "Tag expression filter, passed as `-t`.";
+    };
+
+    threads = mkOption {
+      type = types.ints.positive;
+      default = 1;
+      description = "Parallel thread count, passed as `-T`.";
+    };
+
+    format = mkOption {
+      type = types.listOf types.str;
+      default = [ "junit:xml" "cucumber:json" ];
+      description = "Report formats, comma-joined and passed as `-f`.";
+    };
+
+    env = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "dev";
+      description = "Karate environment name, passed as `-e` (`karate.env`).";
+    };
+
+    name = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Scenario name filter, passed as `-n`.";
+    };
+
+    environmentVariables = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        RABBITMQ_HOST = "localhost";
+        KAFKA_BOOTSTRAP_SERVERS = "localhost:9092";
+      };
+      description = ''
+        OS environment variables exported before running, e.g. the
+        `RABBITMQ_*`/`KAFKA_*`/`SNOWFLAKE_*` variables read by
+        karate-connect's extensions, or any variable a consumer's own
+        `karate-config.js` relies on.
+      '';
+    };
+
+    jvmArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "-Xmx2g" ];
+      description = "Extra JVM arguments (e.g. heap size, custom system properties).";
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Escape hatch: extra arguments appended verbatim to the Karate CLI invocation.";
+    };
+
+    extraClasspath = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "src/test/fixtures" ];
+      description = ''
+        Extra directories added to the JVM classpath alongside the JAR and
+        `featuresPath`, resolved at runtime against the invoking shell's
+        working directory. Needed when a feature reads a sibling resource via
+        `classpath:...` (e.g. a mock JSON fixture) from outside
+        `featuresPath`.
+      '';
+    };
+  };
+
+  config = { };
+}

--- a/nix/karate-run-options.nix
+++ b/nix/karate-run-options.nix
@@ -77,6 +77,12 @@ in
         `featuresPath`, with no remapping. Only supported on Linux
         (`bubblewrap` is not available on Darwin); evaluation fails with a
         clear error if set on a non-Linux system.
+
+        Must be a real subpath (e.g. `/features`), not `/` itself: the sandbox
+        works by building one fresh, writable root and re-binding `/nix`,
+        `/dev`, `/proc`, `/etc`, `/run`, `/tmp` and the caller's working
+        directory back onto it, so mounting something else directly onto `/`
+        would hide those.
       '';
     };
 
@@ -89,6 +95,34 @@ in
         `-Dkarate.config.dir=<dir>`. Resolved at runtime against the invoking
         shell's working directory. Leave `null` to use Karate's default
         resolution (classpath / current directory).
+      '';
+    };
+
+    karateConfigMountPath = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/karate-config";
+      description = ''
+        Absolute path at which `karateConfigDir` should appear to the running
+        JVM, bind-mounted at run time via `bubblewrap` (`bwrap`) -- the same
+        remapping Docker usage does with `-v <my-specific-karate-config.js>:/karate-config.js`.
+
+        `karate-config.js` (or code it calls into) sometimes reads auxiliary
+        files via a hardcoded absolute path that only makes sense inside that
+        Docker layout, the same problem `featuresMountPath` solves for
+        `featuresPath`. Setting `karateConfigMountPath = "/karate-config"`
+        with `karateConfigDir = "it/config"` makes `it/config` (resolved
+        against the invoking shell's working directory) appear as
+        `/karate-config` to the JVM -- `-Dkarate.config.dir` is then set to
+        the mounted path -- without touching the real host filesystem and
+        without copying anything into the Nix store.
+
+        Leave `null` (the default) to run the JVM directly against
+        `karateConfigDir`, with no remapping. Only supported on Linux
+        (`bubblewrap` is not available on Darwin); evaluation fails with a
+        clear error if set on a non-Linux system. Must be a real subpath (e.g.
+        `/karate-config`), not `/` itself, for the same reason as
+        `featuresMountPath`.
       '';
     };
 

--- a/nix/karate-run-options.nix
+++ b/nix/karate-run-options.nix
@@ -55,6 +55,31 @@ in
       '';
     };
 
+    featuresMountPath = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/features";
+      description = ''
+        Absolute path at which `featuresPath` should appear to the running
+        JVM, bind-mounted at run time via `bubblewrap` (`bwrap`) -- the same
+        remapping Docker usage does with `-v <features_path>:/features` (see
+        the Docker image's `VOLUME /features`).
+
+        Feature files are sometimes written to read fixtures via a hardcoded
+        absolute path (e.g. `read('/features/foo.json')`) that only makes
+        sense inside that Docker layout. Setting `featuresMountPath = "/features"`
+        with `featuresPath = "it/features"` makes `it/features` (resolved
+        against the invoking shell's working directory) appear as `/features`
+        to the JVM, without touching the real host `/features` (if any) and
+        without copying anything into the Nix store.
+
+        Leave `null` (the default) to run the JVM directly against
+        `featuresPath`, with no remapping. Only supported on Linux
+        (`bubblewrap` is not available on Darwin); evaluation fails with a
+        clear error if set on a non-Linux system.
+      '';
+    };
+
     karateConfigDir = mkOption {
       type = types.nullOr types.str;
       default = null;

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,46 @@
+# Plain adapter for consumers who don't use flake-parts (or devenv): evaluates
+# the shared `karate-run-options.nix` module directly with `lib.evalModules`
+# and builds the same package/app that the other two adapters produce.
+#
+# Usage in any flake, no flake-parts required:
+#
+#   { inputs, ... }:
+#   {
+#     outputs = { self, nixpkgs, karate-connect, ... }:
+#       let
+#         pkgs = import nixpkgs { system = "x86_64-linux"; };
+#         run = karate-connect.lib.mkKarateRun {
+#           inherit pkgs;
+#           extensions = [ "rabbitmq" "kafka" ];
+#           featuresPath = "src/test/features";
+#         };
+#       in
+#       {
+#         packages.x86_64-linux.karate-test = run.package;
+#         apps.x86_64-linux.karate-test = run.app;
+#       };
+#   }
+{ pkgs
+, lib ? pkgs.lib
+, name ? "default"
+, ...
+}@settings:
+
+let
+  # `pkgs`, `lib` and `name` are consumed here to select the JDK/JAR defaults
+  # and to name the wrapper script; every remaining attribute is a setting
+  # forwarded to the shared options module (extensions, featuresPath, ...).
+  runSettings = builtins.removeAttrs settings [ "pkgs" "lib" "name" ];
+
+  evaluated = lib.evalModules {
+    modules = [
+      (import ./karate-run-options.nix)
+      { config = runSettings; }
+    ];
+    specialArgs = { inherit pkgs name; };
+  };
+in
+import ./build-karate-run.nix {
+  inherit pkgs lib name;
+  cfg = evaluated.config;
+}


### PR DESCRIPTION
## Devenv.sh environment development added

Opt-in dev environment providing JDK 21, Python CLIs,  kubectl , plus  kc-build ,  kc-build-all ,  kc-test ,  kc-docker-build ,  kc-headers  scripts, without touching the system or  .envrc / py_venv

## Nix flake to be able to set up karate parameters in many nix related environment

Lets other Nix projects run karate-connect's Karate CLI against their own features, with configurable extensions, features path,  karate-config.js  location, tags, threads, output format, env vars, and JVM args.

 * Three adapters share one core ( nix/karate-run-options.nix  +  nix/build-karate-run.nix ): flake-parts module ( flakeModules.default ), a plain function ( lib.mkKarateRun ), and a devenv module ( devenvModules.default ).
 * JAR is **fetched from a pinned GitHub Release** ( nix/default-jar.nix ), not rebuilt by Nix.
 * Repo dogfoods itself via  checks.kubernetes-smoke  ( nix flake check ) — offline smoke test using the mocked  cronJob.test.feature

## AGENTS.md for fast LLM context build (optional)

Can be declined in this pull request if contrary to this repository policy.
These developments were AI-assisted.